### PR TITLE
feat: shell startup performance improvements and smarter atuin login

### DIFF
--- a/roles/shell/files/config.fish
+++ b/roles/shell/files/config.fish
@@ -3,8 +3,14 @@ if status is-interactive
     set -g fish_greeting ""
 
     # PATH extras (prepend so brew/local bins win)
-    fish_add_path -m ~/.local/bin
-    fish_add_path -m ~/.cargo/bin
+# Fast PATH prepend without universal variable writes
+function _add_path_fast
+    for dir in $argv
+        set -gx PATH $dir $PATH
+    end
+end
+_add_path_fast ~/.local/bin
+_add_path_fast ~/.cargo/bin
 
     # Environment
     set -gx EDITOR nvim

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -159,8 +159,22 @@
 
 # bw sync is handled by the bitwarden role earlier in the play — skip here.
 
-# Skip BW round-trip when already logged in — atuin key file is the source of truth.
-- name: Check if atuin already has a key on disk
+# Skip BW round-trip when already logged in — atuin sync status is the source of truth.
+- name: Check Atuin sync status
+  ansible.builtin.command: atuin status
+  register: atuin_status_cmd
+  changed_when: false
+  failed_when: false
+  environment:
+    PATH: "/home/linuxbrew/.linuxbrew/bin:{{ ansible_facts['env']['PATH'] }}"
+  tags: [secrets]
+
+- name: Set Atuin logged in fact
+  ansible.builtin.set_fact:
+    atuin_logged_in: "{{ atuin_status_cmd.rc == 0 and '[Sync]' in atuin_status_cmd.stdout }}"
+  tags: [secrets]
+
+- name: Check if atuin key exists
   ansible.builtin.stat:
     path: ~/.local/share/atuin/key
   register: atuin_existing_key
@@ -175,16 +189,16 @@
   no_log: true
   changed_when: false
   failed_when: false
-  when: not atuin_existing_key.stat.exists
+  when: not atuin_logged_in
   environment:
     BW_SESSION: "{{ bw_session | default('') }}"
     PATH: "/home/linuxbrew/.linuxbrew/bin:{{ ansible_facts['env']['PATH'] }}"
   tags: [secrets]
 
-- name: Skip atuin login (already keyed)
+- name: Skip atuin login (already logged in)
   ansible.builtin.set_fact:
     atuin_bw_item: { rc: 1, stdout: "" }
-  when: atuin_existing_key.stat.exists
+  when: atuin_logged_in
   tags: [secrets]
 
 - name: Warn if atuin.sh not found in Bitwarden
@@ -193,7 +207,7 @@
       Bitwarden item 'atuin.sh' not found or vault locked — skipping atuin login.
       Run 'bw unlock' on this machine and re-run, or log in to atuin manually.
   when:
-    - not atuin_existing_key.stat.exists
+    - not atuin_logged_in
     - atuin_bw_item.rc != 0 or (atuin_bw_item.stdout | default('')) | length == 0
   tags: [secrets]
 
@@ -209,20 +223,13 @@
 # NOTE: We do NOT write atuin_key (mnemonic) to ~/.local/share/atuin/key directly.
 # Atuin expects that file to be a base64-encoded binary key.
 # Running 'atuin login -k' with the mnemonic correctly generates the binary key file.
-- name: Check if atuin key exists (indicates already logged in)
-  ansible.builtin.stat:
-    path: ~/.local/share/atuin/key
-  register: atuin_session
-  when: atuin_bw_item.rc == 0 and (atuin_bw_item.stdout | default("")) | length > 0
-  tags: [secrets]
-
 - name: Remove atuin data directory before fresh login
   ansible.builtin.file:
     path: ~/.local/share/atuin
     state: absent
   when: >
     atuin_bw_item.rc == 0 and (atuin_bw_item.stdout | default("")) | length > 0
-    and not atuin_session.stat.exists
+    and not atuin_existing_key.stat.exists
   tags: [secrets]
 
 - name: Login to atuin sync
@@ -230,7 +237,7 @@
     atuin login -u "{{ atuin_username }}" -p "{{ atuin_password }}" -k "{{ atuin_key }}"
   when: >
     atuin_bw_item.rc == 0 and (atuin_bw_item.stdout | default("")) | length > 0
-    and not atuin_session.stat.exists
+    and not atuin_logged_in
   changed_when: true
   environment:
     PATH: "/home/linuxbrew/.linuxbrew/bin:{{ ansible_facts['env']['PATH'] }}"

--- a/roles/shell/templates/zshrc.j2
+++ b/roles/shell/templates/zshrc.j2
@@ -26,14 +26,27 @@ export PATH="$HOME/.local/bin:$PATH"
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
 # ── Completion ───────────────────────────────────────────────────
+# Use a compilation cache to speed up startup (rebuilt once a day)
+_comp_dumpfile="${XDG_CACHE_HOME:-$HOME/.cache}/zcompdump"
 autoload -Uz compinit
-compinit -d "${XDG_CACHE_HOME:-$HOME/.cache}/zcompdump"
+# Ensure EXTENDED_GLOB is set for the glob qualifier
+setopt EXTENDED_GLOB
+if [[ -n "$_comp_dumpfile"(#qN.mh-24) ]]; then
+  compinit -C -d "$_comp_dumpfile"
+else
+  compinit -d "$_comp_dumpfile"
+  # Compile the completion dump file for faster loading in the background
+  { zcompile "$_comp_dumpfile" } &!
+fi
 zstyle ':completion:*' menu select
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'  # case-insensitive
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
 
 # ── Bluefin CLI (eza, bat, zoxide, starship, atuin, fzf) ─────────
-command -v bluefin-cli &>/dev/null && eval "$(bluefin-cli init zsh)"
+if command -v bluefin-cli &>/dev/null; then
+  # Intercept and bypass the slow MOTD execution to speed up startup
+  eval "$(bluefin-cli init zsh | sed 's/bluefin-cli motd show/true/')"
+fi
 
 # ── direnv ───────────────────────────────────────────────────────
 command -v direnv &>/dev/null && eval "$(direnv hook zsh)"

--- a/site.yml
+++ b/site.yml
@@ -29,6 +29,8 @@
       tags: [system, packages, apk]
     - role: homebrew
       tags: [packages, homebrew]
+    - role: bitwarden
+      tags: [secrets, bitwarden]
     - role: shell
       tags: [dotfiles, shell]
     - role: git
@@ -37,8 +39,6 @@
       tags: [dotfiles, neovim, editor]
 
     # Phase 2: Secrets + auth
-    - role: bitwarden
-      tags: [secrets, bitwarden]
     - role: ssh_keys
       tags: [secrets, ssh, ssh_keys]
     - role: github


### PR DESCRIPTION
## Summary

- **fish**: replace `fish_add_path -m` with a fast PATH prepend function that avoids writing to universal variables on every shell start
- **zsh**: cache the completion dump file and skip rebuild if it's under 24 hours old; recompile in the background when it does regenerate
- **zsh**: bypass the slow `bluefin-cli motd show` call during shell init
- **atuin**: use `atuin status` to detect sync login state instead of checking for the key file on disk — more accurate, handles the case where the file exists but the user isn't actually logged in
- **site.yml**: move `bitwarden` role before `shell` so the BW session is available when shell tasks need it for atuin

## Test plan

- [ ] Open a new zsh shell and verify startup is noticeably faster
- [ ] Open a new fish shell and verify PATH is correct (`echo $PATH`)
- [ ] Run `just apply` and confirm atuin login step behaves correctly (skips if already logged in, logs in if not)
- [ ] Verify completions still work in zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)