### PR TITLE
docs: add ADOPTERS.md for Hive

### DIFF
--- a/talos-k8s/hive/ADOPTERS.md
+++ b/talos-k8s/hive/ADOPTERS.md
@@ -1,0 +1,14 @@
+# Adopters
+
+Listed below are organizations that have adopted Hive in one way or another.
+We are delighted to welcome them to the Hive community. If you are using Hive
+in your organization, we would love to add you to the list below. You can open
+a pull request against this file directly.
+
+| Organization | Description of Use |
+| ------------ | ------------------ |
+| [Tuna OS](https://github.com/tuna-os) | Tuna OS deploys Hive as a 24/7 AI agent supervisor on a 2-node Talos Linux K8s cluster running at ACMM L6 (full autonomy — issues, PRs, auto-merge). Nine long-running goose agents (supervisor, scanner, ci-maintainer, quality, guide, sec-check, architect, strategist, outreach) autonomously triage issues, propose fixes, audit dependencies, and maintain roadmap visibility across `tuna-os/tunaos` and `tuna-os/tacklebox`. Backend is DeepSeek-V4-Pro via the goose CLI. Tuna OS also runs the KubeStellar Hive Console to contribute idle GPU capacity back to the upstream Hive network, backed by a self-hosted Qwen3.6-27B model on the same cluster. |
+
+<!-- append the line below to the table
+| [name](URL) | brief description of how you are using Hive |
+-->


### PR DESCRIPTION
Adds an ADOPTERS.md for the Hive AI agent supervisor with Tuna OS as the inaugural adopter.

Tuna OS runs Hive at ACMM L6 on a 2-node Talos Linux K8s cluster with 9 goose agents managing `tuna-os/tunaos` and `tuna-os/tacklebox`, and also runs the KubeStellar Hive Console to contribute GPU capacity back to the upstream network.